### PR TITLE
Drop ineffective cleanup commands

### DIFF
--- a/com.jeffser.Pigment.json
+++ b/com.jeffser.Pigment.json
@@ -13,13 +13,7 @@
   "cleanup": [
     "/include",
     "/lib/pkgconfig",
-    "/man",
-    "/share/doc",
-    "/share/gtk-doc",
-    "/share/man",
-    "/share/pkgconfig",
-    "*.la",
-    "*.a"
+    "/share/gir-1.0"
   ],
   "modules": [
     {
@@ -68,7 +62,8 @@
         {
           "type": "git",
           "url": "https://github.com/flatpak/libportal.git",
-          "tag": "0.9.1"
+          "tag": "0.9.1",
+          "commit": "8f5dc8d192f6e31dafe69e35219e3b707bde71ce"
         }
       ]
     },


### PR DESCRIPTION
- Drop ineffective cleanup commands
- Improve cleanup commands to reduce the Flatpak size
- Add missing commit ID to fix linter warnings